### PR TITLE
add override to have ghga imprint

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -33,6 +33,7 @@ copyright: 2023 The GHGA Team
 # Theming, Configuration
 theme:
   name: material
+  custom_dir: overrides
   logo: logo.svg
   font: false
   palette:

--- a/overrides/partials/copyright.html
+++ b/overrides/partials/copyright.html
@@ -1,0 +1,43 @@
+<!--
+  Copyright (c) 2016-2024 Martin Donath <martin.donath@squidfunk.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
+<!-- Copyright and theme information -->
+<div class="md-copyright">
+    {% if config.copyright %}
+      <div class="md-copyright__highlight">
+        {{ config.copyright }}
+      </div>
+     {% endif %}
+    {% if not config.extra.generator == false %}
+      Made with
+      <a
+        href="https://squidfunk.github.io/mkdocs-material/"
+        target="_blank" rel="noopener"
+      >
+        Material for MkDocs
+      </a>
+
+    <!-- Imprint-->
+      | <a href="https://www.ghga.de/imprint/" target="_blank" rel="noopener">Imprint</a>  
+
+    {% endif %}
+  </div>


### PR DESCRIPTION
Adding a link to the GHGA.de Imprint in the footer area.