### PR TITLE
added the importance: required|recommended|optional to each of the fi…

### DIFF
--- a/user_docs/metadata/data_dictionary/Analysis.md
+++ b/user_docs/metadata/data_dictionary/Analysis.md
@@ -7,28 +7,42 @@ An Analysis is a data transformation that transforms input data to output data.
 ### ***analysis_method***
 **description** : The alias of the Analysis Method that is associated with this Analysis.<br>
 **required** : True<br>
-**data type** : AnalysisMethod <br>
+**importance** : required<br>
+**data_type** : AnalysisMethod<br>
+
 ### ***title***
 **description** : The title that describes an entity.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***description***
 **description** : A description summarizing how this Analysis was carried out (e.g., description of computational tools, pipelines, workflows).<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***type***
 **description** : The type of this Analysis.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***ega_accession***
 **description** : The EGA accession of the 'Analysis' entity (EGAZ).<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***research_data_files***
 **description** : One or more aliases of the Research Data Files that this Analysis used as input to create Process Data Files.<br>
 **required** : True<br>
-**data type** : ResearchDataFile <br>
+**importance** : required<br>
+**data_type** : ResearchDataFile<br>
+
 ### ***alias***
 **description** : The alias for an entity at the time of submission.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+

--- a/user_docs/metadata/data_dictionary/AnalysisMethod.md
+++ b/user_docs/metadata/data_dictionary/AnalysisMethod.md
@@ -7,44 +7,66 @@ An Analysis Method captures the workflow steps that were performed to analyze da
 ### ***name***
 **description** : A name identifying this Analysis Method.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***description***
 **description** : Description of an entity.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***type***
 **description** : The type of an entity. Note: Not to be confused with rdf:type.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***workflow_name***
 **description** : The workflow name.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***workflow_version***
 **description** : The workflow version.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : recommended<br>
+**data_type** : string<br>
+
 ### ***workflow_repository***
 **description** : The workflow repository (e.g., the URL).<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***workflow_doi***
 **description** : A digital object identifier for the workflow. Can be a publication or the workflow commit that was used for the Analysis.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***workflow_tasks***
 **description** : Tasks performed by the workflow<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : recommended<br>
+**data_type** : string<br>
+
 ### ***parameters***
 **description** : Key/value pairs where key corresponds to a parameter name and value corresponds to a parameter value (e.g., 'aligner' = 'star_salmon',  'hisat2_build_memory' = '200.GB', 'split_fastq' = 50000000).<br>
 **required** : False<br>
-**data type** : Attribute <br>
+**importance** : recommended<br>
+**data_type** : Attribute<br>
+
 ### ***software_versions***
 **description** : key/value pairs where key corresponds to a software name and value corresponds to a version descriptor (e.g., `salmon` = '1.3.0', `trim-galore` = '0.6.6', `bedtools` = '2.29.2').<br>
 **required** : False<br>
-**data type** : Attribute <br>
+**importance** : recommended<br>
+**data_type** : Attribute<br>
+
 ### ***alias***
 **description** : The alias for an entity at the time of submission.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+

--- a/user_docs/metadata/data_dictionary/AnalysisMethodSupportingFile.md
+++ b/user_docs/metadata/data_dictionary/AnalysisMethodSupportingFile.md
@@ -7,7 +7,8 @@ An Analysis Method Supporting File is a File that contains additional informatio
 ### ***format***
 **description** : The file format of the Supporting File (e.g., TXT, JSON).<br>
 **required** : True<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : required<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -21,27 +22,40 @@ An Analysis Method Supporting File is a File that contains additional informatio
 | `OTHER` | `A file format not captured by the controlled vocabulary.` |
 ///
 
+
 ### ***analysis_method***
 **description** : The Analysis Process associated with an entity.<br>
 **required** : True<br>
-**data type** : AnalysisMethod <br>
+**importance** : required<br>
+**data_type** : AnalysisMethod<br>
+
 ### ***name***
 **description** : The given filename.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***dataset***
 **description** : The Dataset alias associated with this File.<br>
 **required** : True<br>
-**data type** : Dataset <br>
+**importance** : required<br>
+**data_type** : Dataset<br>
+
 ### ***ega_accession***
 **description** : The EGA accession ID of an entity.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***included_in_submission***
 **description** : Whether a File is included in the Submission or not.<br>
 **required** : True<br>
-**data type** : boolean <br>
+**importance** : required<br>
+**data_type** : boolean<br>
+
 ### ***alias***
 **description** : The alias for an entity at the time of submission.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+

--- a/user_docs/metadata/data_dictionary/DataAccessCommittee.md
+++ b/user_docs/metadata/data_dictionary/DataAccessCommittee.md
@@ -7,16 +7,24 @@ A group of members that are delegated to grant access to one or more datasets af
 ### ***email***
 **description** : The email of the Data Access Committee (e.g., DAC[at]email.com). This property must not include any personally identifiable data.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***institute***
 **description** : The Institute a person is affiliated with.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***ega_accession***
 **description** : The EGA accession ID of an entity.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***alias***
 **description** : The alias for an entity at the time of submission.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+

--- a/user_docs/metadata/data_dictionary/DataAccessPolicy.md
+++ b/user_docs/metadata/data_dictionary/DataAccessPolicy.md
@@ -7,23 +7,32 @@ A Data Access Policy specifies under which circumstances, legal or otherwise, a 
 ### ***name***
 **description** : A name for this Data Access Policy.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***description***
 **description** : A short description for this Data Access Policy.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***policy_text***
 **description** : The complete text for the Data Access Policy.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***policy_url***
 **description** : An alternative to the Data Access Policy text is to provide the URL for the policy. This is useful if the terms of the policy are available online at a resolvable URL.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : recommended<br>
+**data_type** : string<br>
+
 ### ***data_use_permission_term***
 **description** : The Data Use Permission associated with this Data Use Policy. The used term should be a descendant of 'DUO:0000001: data use permission' (e.g., no restriction).<br>
 **required** : True<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : required<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -35,14 +44,18 @@ A Data Access Policy specifies under which circumstances, legal or otherwise, a 
 | `POPULATION_ORIGINS_OR_ANCESTRY_RESEARCH_ONLY` | `This data use permission indicates that use of the data is limited to the study of population origins or ancestry.` |
 ///
 
+
 ### ***data_use_permission_id***
 **description** : The DUO ID corresponding to the Data Use Permission term (e.g., DUO:0000004).<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***data_use_modifier_terms***
 **description** : One or more Data Use Modifiers for the Data Use Permission associated with this Data Use Policy. The used terms should be descendants of 'DUO:0000017: data use modifier' (e.g., clinical care use). Please use 'USER_SPECIFIC_RESTRICTION' if no other modifier applies.<br>
 **required** : False<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : recommended<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -67,19 +80,28 @@ A Data Access Policy specifies under which circumstances, legal or otherwise, a 
 | `POPULATION_ORIGINS_OR_ANCESTRY_RESEARCH_PROHIBITED` | `This data use modifier indicates use for purposes of population, origin, or ancestry research is prohibited.` |
 ///
 
+
 ### ***data_use_modifier_ids***
 **description** : The DUO IDs corresponding to the Data Use Modifier terms (e.g., DUO:0000043).<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : recommended<br>
+**data_type** : string<br>
+
 ### ***ega_accession***
 **description** : The EGA accession ID of an entity.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***data_access_committee***
 **description** : The Data Access Committee linked to this Data Use Policy.<br>
 **required** : True<br>
-**data type** : DataAccessCommittee <br>
+**importance** : required<br>
+**data_type** : DataAccessCommittee<br>
+
 ### ***alias***
 **description** : The alias for an entity at the time of submission.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+

--- a/user_docs/metadata/data_dictionary/Dataset.md
+++ b/user_docs/metadata/data_dictionary/Dataset.md
@@ -7,28 +7,42 @@ A Dataset is a collection of Files that is prepared for distribution and is tied
 ### ***title***
 **description** : A title for this Dataset.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***description***
 **description** : A description summarizing this Dataset.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***types***
 **description** : The type of this Dataset.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***ega_accession***
 **description** : The EGA accession ID of an entity.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***data_access_policy***
 **description** : The Data Access Policy that applies to this Dataset.<br>
 **required** : True<br>
-**data type** : DataAccessPolicy <br>
+**importance** : required<br>
+**data_type** : DataAccessPolicy<br>
+
 ### ***study***
 **description** : The Study associated with this Dataset.<br>
 **required** : True<br>
-**data type** : Study <br>
+**importance** : required<br>
+**data_type** : Study<br>
+
 ### ***alias***
 **description** : The alias for an entity at the time of submission.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+

--- a/user_docs/metadata/data_dictionary/Experiment.md
+++ b/user_docs/metadata/data_dictionary/Experiment.md
@@ -7,32 +7,48 @@ An Experiment is an investigation that consists of a coordinated set of actions 
 ### ***experiment_method***
 **description** : The alias of one or more Experiment Methods that are associated with this Experiment.<br>
 **required** : True<br>
-**data type** : ExperimentMethod <br>
+**importance** : required<br>
+**data_type** : ExperimentMethod<br>
+
 ### ***title***
 **description** : The title for this Experiment (e.g., GHGAE_PBMC_RNAseq).<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***description***
 **description** : A detailed description of this Experiment.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***type***
 **description** : The type of this Experiment.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***ega_accession***
 **description** : The EGA accession of the 'Run' entity (EGAR).<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***sample***
 **description** : The alias of one or more Samples that are associated with this Experiment.<br>
 **required** : True<br>
-**data type** : Sample <br>
+**importance** : required<br>
+**data_type** : Sample<br>
+
 ### ***attributes***
 **description** : Key/value pairs corresponding to an entity.<br>
 **required** : False<br>
-**data type** : Attribute <br>
+**importance** : optional<br>
+**data_type** : Attribute<br>
+
 ### ***alias***
 **description** : The alias for an entity at the time of submission.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+

--- a/user_docs/metadata/data_dictionary/ExperimentMethod.md
+++ b/user_docs/metadata/data_dictionary/ExperimentMethod.md
@@ -7,19 +7,26 @@ The Experiment Method captures technical metadata describing the parameters used
 ### ***name***
 **description** : A short name identifying this Experiment Method.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***description***
 **description** : A short description of this Experiment Method.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***type***
 **description** : The type associated with this Experiment Method.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***library_type***
 **description** : Describe the level of omics analysis (e.g., WGS, ATAC).<br>
 **required** : True<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : required<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -38,10 +45,12 @@ The Experiment Method captures technical metadata describing the parameters used
 | `OTHER` | `A library type not captured by the above vocabulary.` |
 ///
 
+
 ### ***library_selection_methods***
 **description** : One or more methods used to select for or against, enrich, or screen the material being sequenced (e.g., random, PCA, cDNA).<br>
 **required** : True<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : required<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -73,14 +82,18 @@ The Experiment Method captures technical metadata describing the parameters used
 | `OTHER` | `Other library enrichment, screening, or selection process.` |
 ///
 
+
 ### ***library_preparation***
 **description** : The general method for preparation of the sequencing library (e.g., KAPA PCR-free).<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***library_preparation_kit_retail_name***
 **description** : The retail name for the kit used to construct a genomic library. This may include the vendor name, kit name and kit version (e.g., Agilent sure select Human Exome V8, Twist RefSeq Exome).<br>
 **required** : False<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : recommended<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -249,14 +262,18 @@ The Experiment Method captures technical metadata describing the parameters used
 | `OTHER` | `A Library Preparation Kit not captured by the controlled vocabulary.` |
 ///
 
+
 ### ***library_preparation_kit_manufacturer***
 **description** : The manufacturer of the kit used for library preparation.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : recommended<br>
+**data_type** : string<br>
+
 ### ***primer***
 **description** : The type of primer used for reverse transcription (e.g., oligo-dT or random).<br>
 **required** : False<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : recommended<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -267,10 +284,12 @@ The Experiment Method captures technical metadata describing the parameters used
 | `OTHER` | `A primer not captured by the controlled vocabulary.` |
 ///
 
+
 ### ***end_bias***
 **description** : The end of the cDNA molecule that is preferentially sequenced (e.g., 3/5 prime end, full-length).<br>
 **required** : False<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : recommended<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -280,14 +299,18 @@ The Experiment Method captures technical metadata describing the parameters used
 | `FULL_LENGTH` | `Captures the full length of the targeted molecule.` |
 ///
 
+
 ### ***target_regions***
 **description** : Subset of genes or specific regions of the genome, which are most likely to be involved in the phenotype under study.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***rnaseq_strandedness***
 **description** : The strandedness of the library, whether reads come from both strands of the cDNA or only from the first (antisense) or the second (sense) strand.<br>
 **required** : False<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : recommended<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -297,10 +320,12 @@ The Experiment Method captures technical metadata describing the parameters used
 | `UNSTRANDED` | `Non-directional sequencing, where the reads can map from either the transcript strand or its complement.` |
 ///
 
+
 ### ***instrument_model***
 **description** : The name and model of the technology platform used to perform sequencing.<br>
 **required** : True<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : required<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -373,18 +398,24 @@ The Experiment Method captures technical metadata describing the parameters used
 | `OTHER` | `Other instrument model than mentioned above.` |
 ///
 
+
 ### ***sequencing_center***
 **description** : Center where sample was sequenced.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : recommended<br>
+**data_type** : string<br>
+
 ### ***sequencing_read_length***
 **description** : Length of sequencing reads (e.g., long or short or actual number of the read length).<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***sequencing_layout***
 **description** : Describe whether the library was sequenced in single-end (forward or reverse) or paired-end mode.<br>
 **required** : True<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : required<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -393,18 +424,24 @@ The Experiment Method captures technical metadata describing the parameters used
 | `PE` | `Paired end sequencing.` |
 ///
 
+
 ### ***target_coverage***
 **description** : Mean coverage for whole genome sequencing, or mean target coverage for whole exome and targeted sequencing, (i.e. the number of times a particular locus was sequenced).<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***flow_cell_id***
 **description** : Flow cell ID (e.g., Experiment ID_Cell 1_Lane_1).<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : recommended<br>
+**data_type** : string<br>
+
 ### ***flow_cell_type***
 **description** : Type of flow cell used (e.g., S4, S2 for NovaSeq; PromethION, Flongle for Nanopore).<br>
 **required** : False<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : recommended<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -418,10 +455,12 @@ The Experiment Method captures technical metadata describing the parameters used
 | `OTHER` | `Usage of a flow cell not captured by the controlled vocabulary.` |
 ///
 
+
 ### ***sample_barcode_read***
 **description** : The type of read that contains the sample barcode (e.g., index1, index2, read1, read2).<br>
 **required** : False<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : recommended<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -431,15 +470,22 @@ The Experiment Method captures technical metadata describing the parameters used
 | `OTHER` | `Sample barcode read is neither in Index 1 or Index 1 and Index 2.` |
 ///
 
+
 ### ***ega_accession***
 **description** : The EGA accession of the 'Experiment' entity (EGAX).<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***attributes***
 **description** : One or more attributes that further characterize this Experiment Method.<br>
 **required** : False<br>
-**data type** : Attribute <br>
+**importance** : optional<br>
+**data_type** : Attribute<br>
+
 ### ***alias***
 **description** : The alias for an entity at the time of submission.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+

--- a/user_docs/metadata/data_dictionary/ExperimentMethodSupportingFile.md
+++ b/user_docs/metadata/data_dictionary/ExperimentMethodSupportingFile.md
@@ -7,7 +7,8 @@ An Experiment Method Supporting File is a File that contains additional informat
 ### ***format***
 **description** : The file format of the Supporting File (e.g., TXT, JSON).<br>
 **required** : True<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : required<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -21,27 +22,40 @@ An Experiment Method Supporting File is a File that contains additional informat
 | `OTHER` | `A file format not captured by the controlled vocabulary.` |
 ///
 
+
 ### ***experiment_method***
 **description** : The Experiment Method associated with an entity.<br>
 **required** : True<br>
-**data type** : ExperimentMethod <br>
+**importance** : required<br>
+**data_type** : ExperimentMethod<br>
+
 ### ***name***
 **description** : The given filename.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***dataset***
 **description** : The Dataset alias associated with this File.<br>
 **required** : True<br>
-**data type** : Dataset <br>
+**importance** : required<br>
+**data_type** : Dataset<br>
+
 ### ***ega_accession***
 **description** : The EGA accession ID of an entity.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***included_in_submission***
 **description** : Whether a File is included in the Submission or not.<br>
 **required** : True<br>
-**data type** : boolean <br>
+**importance** : required<br>
+**data_type** : boolean<br>
+
 ### ***alias***
 **description** : The alias for an entity at the time of submission.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+

--- a/user_docs/metadata/data_dictionary/Individual.md
+++ b/user_docs/metadata/data_dictionary/Individual.md
@@ -7,23 +7,32 @@ An Individual is a Person who is participating in a Study.
 ### ***phenotypic_features_terms***
 **description** : The phenotypic feature concepts that the entity is associated with at the time of retrieval from the organism. The Phenotypic Feature is captured using a concept from the Human Phenotype Ontology (e.g., Lymph node hypoplasia, Cough, Hypotension).<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : recommended<br>
+**data_type** : string<br>
+
 ### ***phenotypic_features_ids***
 **description** : The corresponding ID to the HPO vocabulary (e.g., HP:0002732, HP:0012735, HP:0002615).<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : recommended<br>
+**data_type** : string<br>
+
 ### ***diagnosis_ids***
 **description** : One or more diagnoses that the entity is associated with at the time of retrieval from the organism. The diagnosis is captured using a code from ICD-10 (WHO version). Please restrict the ICD code to the chapter letter and two digits for the main diagnosis (e.g., E10, C01).<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : recommended<br>
+**data_type** : string<br>
+
 ### ***diagnosis_terms***
 **description** : The ICD-10 terms corresponding to the ICD-10 codes (e.g., Type 1 diabetes mellitus, Malignant neoplasm of base of tongue).<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : recommended<br>
+**data_type** : string<br>
+
 ### ***sex***
 **description** : The genotypic sex of the Individual (e.g., female).<br>
 **required** : True<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : required<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -34,23 +43,34 @@ An Individual is a Person who is participating in a Study.
 | `OTHER` | `A sex not captured by the controlled vocabulary.` |
 ///
 
+
 ### ***geographical_region_term***
 **description** : The geographical region where the Individual is located. The Geographical Region is captured using a concept from the NCIT "country" class (NCIT:C25464) (e.g., Austria, Germany, Italy).<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***geographical_region_id***
 **description** : The corresponding ID to the NCIT vocabulary (e.g., NCIT:C16312, NCIT:C16636, NCIT:C16761).<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***ancestry_terms***
 **description** : A person's descent or lineage from a population. The Ancestry is captured using a concept from the Human Ancestry Ontology "ancestry category" (HANCESTRO:0004) branch (e.g., African, European, Oceanian).<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***ancestry_ids***
 **description** : The corresponding ID to the HANCESTRO vocabulary (e.g., HANCESTRO:0010, HANCESTRO:0005, HANCESTRO:0017).<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***alias***
 **description** : The alias for an entity at the time of submission.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+

--- a/user_docs/metadata/data_dictionary/IndividualSupportingFile.md
+++ b/user_docs/metadata/data_dictionary/IndividualSupportingFile.md
@@ -7,7 +7,8 @@ An Individual Supporting File is a File that contains additional information rel
 ### ***format***
 **description** : The file format of the Supporting File (e.g., TXT, JSON).<br>
 **required** : True<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : required<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -21,27 +22,40 @@ An Individual Supporting File is a File that contains additional information rel
 | `OTHER` | `A file format not captured by the controlled vocabulary.` |
 ///
 
+
 ### ***individual***
 **description** : The Individual associated with an entity.<br>
 **required** : True<br>
-**data type** : Individual <br>
+**importance** : required<br>
+**data_type** : Individual<br>
+
 ### ***name***
 **description** : The given filename.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***dataset***
 **description** : The Dataset alias associated with this File.<br>
 **required** : True<br>
-**data type** : Dataset <br>
+**importance** : required<br>
+**data_type** : Dataset<br>
+
 ### ***ega_accession***
 **description** : The EGA accession ID of an entity.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***included_in_submission***
 **description** : Whether a File is included in the Submission or not.<br>
 **required** : True<br>
-**data type** : boolean <br>
+**importance** : required<br>
+**data_type** : boolean<br>
+
 ### ***alias***
 **description** : The alias for an entity at the time of submission.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+

--- a/user_docs/metadata/data_dictionary/ProcessDataFile.md
+++ b/user_docs/metadata/data_dictionary/ProcessDataFile.md
@@ -7,7 +7,8 @@ A Process Data File is a File that contains data produced by an Analysis or work
 ### ***format***
 **description** : The file format of the Process Data File (e.g., CRAM, BAM).<br>
 **required** : True<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : required<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -25,27 +26,40 @@ A Process Data File is a File that contains data produced by an Analysis or work
 | `OTHER` | `A file format not captured by the controlled vocabulary.` |
 ///
 
+
 ### ***analysis***
 **description** : The alias of the Analysis that produced this Process Data File.<br>
 **required** : True<br>
-**data type** : Analysis <br>
+**importance** : required<br>
+**data_type** : Analysis<br>
+
 ### ***name***
 **description** : The given filename.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***dataset***
 **description** : The Dataset alias associated with this File.<br>
 **required** : True<br>
-**data type** : Dataset <br>
+**importance** : required<br>
+**data_type** : Dataset<br>
+
 ### ***ega_accession***
 **description** : The EGA accession ID of an entity.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***included_in_submission***
 **description** : Whether a File is included in the Submission or not.<br>
 **required** : True<br>
-**data type** : boolean <br>
+**importance** : required<br>
+**data_type** : boolean<br>
+
 ### ***alias***
 **description** : The alias for an entity at the time of submission.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+

--- a/user_docs/metadata/data_dictionary/Publication.md
+++ b/user_docs/metadata/data_dictionary/Publication.md
@@ -7,36 +7,54 @@ A Publication represents an article that is published. The minimum expectation i
 ### ***study***
 **description** : The Study entity associated with this Publication.<br>
 **required** : True<br>
-**data type** : Study <br>
+**importance** : required<br>
+**data_type** : Study<br>
+
 ### ***title***
 **description** : The title for this Publication.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***abstract***
 **description** : The study abstract that describes the goals. Can also hold abstract from a publication related to this Study.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***author***
 **description** : Author(s) of this Publication.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***year***
 **description** : The year in which the paper was published.<br>
 **required** : False<br>
-**data type** : integer <br>
+**importance** : optional<br>
+**data_type** : integer<br>
+
 ### ***journal***
 **description** : The name of the journal.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***doi***
 **description** : DOI identifier of a publication.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***xref***
 **description** : One or more cross-references for this Publication.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***alias***
 **description** : The alias for an entity at the time of submission.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+

--- a/user_docs/metadata/data_dictionary/ResearchDataFile.md
+++ b/user_docs/metadata/data_dictionary/ResearchDataFile.md
@@ -7,7 +7,8 @@ A Research Data File is a File that contains raw data originating from an Experi
 ### ***format***
 **description** : The file format of the Research Data File (e.g., FASTQ, uBAM, FASTA).<br>
 **required** : True<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : required<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -23,35 +24,52 @@ A Research Data File is a File that contains raw data originating from an Experi
 | `OTHER` | `A file format not captured by the controlled vocabulary.` |
 ///
 
+
 ### ***technical_replicate***
 **description** : An integer to indicate the technical replicate of this File.<br>
 **required** : True<br>
-**data type** : integer <br>
+**importance** : required<br>
+**data_type** : integer<br>
+
 ### ***sequencing_lane_id***
 **description** : The identifier of a sequencing lane.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : recommended<br>
+**data_type** : string<br>
+
 ### ***experiments***
 **description** : The aliases of the Experiments that produced this Research Data File.<br>
 **required** : True<br>
-**data type** : Experiment <br>
+**importance** : required<br>
+**data_type** : Experiment<br>
+
 ### ***name***
 **description** : The given filename.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***dataset***
 **description** : The Dataset alias associated with this File.<br>
 **required** : True<br>
-**data type** : Dataset <br>
+**importance** : required<br>
+**data_type** : Dataset<br>
+
 ### ***ega_accession***
 **description** : The EGA accession ID of an entity.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***included_in_submission***
 **description** : Whether a File is included in the Submission or not.<br>
 **required** : True<br>
-**data type** : boolean <br>
+**importance** : required<br>
+**data_type** : boolean<br>
+
 ### ***alias***
 **description** : The alias for an entity at the time of submission.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+

--- a/user_docs/metadata/data_dictionary/Sample.md
+++ b/user_docs/metadata/data_dictionary/Sample.md
@@ -7,15 +7,20 @@ A Sample is a limited quantity of something to be used for testing, analysis, in
 ### ***individual***
 **description** : The alias of the Individual entity from which this Biospecimen or Sample was derived.<br>
 **required** : True<br>
-**data type** : Individual <br>
+**importance** : required<br>
+**data_type** : Individual<br>
+
 ### ***name***
 **description** : A descriptive name of this Sample (e.g., GHGAS_Blood_Sample1 or GHGAS_PBMC_RNAseq_S1). This property must not include any personally identifiable data.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***type***
 **description** : The type of the Sample.<br>
 **required** : False<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : optional<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -35,18 +40,24 @@ A Sample is a limited quantity of something to be used for testing, analysis, in
 | `TOTAL_RNA` | `Total RNA was used for sequencing.` |
 ///
 
+
 ### ***biological_replicate***
 **description** : An integer to indicate the number of a biological replicate.<br>
 **required** : None<br>
-**data type** : integer <br>
+**importance** : recommended<br>
+**data_type** : integer<br>
+
 ### ***description***
 **description** : A concise description about the Sample source, the collection method, and the protocol which was followed to process this Sample.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***storage***
 **description** : Methods by which a Sample is stored.<br>
 **required** : False<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : recommended<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -60,10 +71,12 @@ A Sample is a limited quantity of something to be used for testing, analysis, in
 | `UNKNOWN` | `The storage method is unknown.` |
 ///
 
+
 ### ***disease_or_healthy***
 **description** : Whether a Condition corresponds to a disease or a healthy state.<br>
 **required** : False<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : recommended<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -73,10 +86,12 @@ A Sample is a limited quantity of something to be used for testing, analysis, in
 | `NOT_APPLICABLE` | `The distinction is not applicaple.` |
 ///
 
+
 ### ***case_control_status***
 **description** : Whether a Condition corresponds to a treatment or a control.<br>
 **required** : True<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : required<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -87,30 +102,42 @@ A Sample is a limited quantity of something to be used for testing, analysis, in
 | `UNKNOWN` | `The participant's status is not known.` |
 ///
 
+
 ### ***ega_accession***
 **description** : The EGA accession ID of an entity.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***xref***
 **description** : One or more cross-references for this Sample (e.g., this Sample may have an EBI BioSamples accession ID).<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***biospecimen_name***
 **description** : A descriptive name of this Biospecimen (e.g., GHGAB_caudate_nucleus_biospecimen). This property must not include any personally identifiable data.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : recommended<br>
+**data_type** : string<br>
+
 ### ***biospecimen_type***
 **description** : The type of Biospecimen.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : recommended<br>
+**data_type** : string<br>
+
 ### ***biospecimen_description***
 **description** : A concise description about the Biospecimen source, the collection method, and the protocol which was followed to process this Biospecimen.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***biospecimen_age_at_sampling***
 **description** : The age of the Individual at the time of isolating this biospecimen.<br>
 **required** : True<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : required<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -135,10 +162,12 @@ A Sample is a limited quantity of something to be used for testing, analysis, in
 | `UNKNOWN` | `Age range unknown.` |
 ///
 
+
 ### ***biospecimen_vital_status_at_sampling***
 **description** : Vital Status of the Individual at the time of isolating this biospecimen (e.g., alive).<br>
 **required** : False<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : recommended<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -148,18 +177,24 @@ A Sample is a limited quantity of something to be used for testing, analysis, in
 | `UNKNOWN` | `Vital status is unknown.` |
 ///
 
+
 ### ***biospecimen_tissue_term***
 **description** : The tissue this Biospecimen originated from. Should be a term from the BRENDA Tissue Ontology vocabulary (e.g., kidney, blood, melanoma cell).<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***biospecimen_tissue_id***
 **description** : The corresponding ontology ID for the biospecimen_tissue_term (e.g., BTO:0000671, BTO:0000089, BTO:0000848).<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***biospecimen_isolation***
 **description** : Method or device employed for collecting/isolating this Biospecimen.<br>
 **required** : False<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : recommended<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -170,10 +205,12 @@ A Sample is a limited quantity of something to be used for testing, analysis, in
 | `BUCCAL_SWAB` | `Sample collection using a buccal swab.` |
 ///
 
+
 ### ***biospecimen_storage***
 **description** : Methods by which this Biospecimen is stored.<br>
 **required** : False<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : recommended<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -187,11 +224,16 @@ A Sample is a limited quantity of something to be used for testing, analysis, in
 | `UNKNOWN` | `The storage method is unknown.` |
 ///
 
+
 ### ***attributes***
 **description** : Key/value pairs corresponding to an entity.<br>
 **required** : False<br>
-**data type** : Attribute <br>
+**importance** : optional<br>
+**data_type** : Attribute<br>
+
 ### ***alias***
 **description** : The alias for an entity at the time of submission.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+

--- a/user_docs/metadata/data_dictionary/Study.md
+++ b/user_docs/metadata/data_dictionary/Study.md
@@ -7,15 +7,20 @@ A Study is an experimental investigation of a particular phenomenon. It involves
 ### ***title***
 **description** : A comprehensive title for this Study.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***description***
 **description** : A detailed description (abstract) that describes the goals of this Study.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***types***
 **description** : One or more types of this Study (e.g., Cancer Genomics, Epigenetics, Exome Sequencing).<br>
 **required** : True<br>
-**data type** : Controlled Vocabulary <br>
+**importance** : required<br>
+**data_type** : Controlled Vocabulary<br>
 
 /// details | Permissible Values
 | Permissible Values | Description |
@@ -57,19 +62,28 @@ A Study is an experimental investigation of a particular phenomenon. It involves
 | `OTHER` | `A study type not captured by the above mentioned.` |
 ///
 
+
 ### ***ega_accession***
 **description** : The EGA accession ID of an entity.<br>
 **required** : False<br>
-**data type** : string <br>
+**importance** : optional<br>
+**data_type** : string<br>
+
 ### ***affiliations***
 **description** : The affiliations associated with this Study.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+
 ### ***attributes***
 **description** : One or more attributes that further characterize this Study.<br>
 **required** : False<br>
-**data type** : Attribute <br>
+**importance** : optional<br>
+**data_type** : Attribute<br>
+
 ### ***alias***
 **description** : The alias for an entity at the time of submission.<br>
 **required** : True<br>
-**data type** : string <br>
+**importance** : required<br>
+**data_type** : string<br>
+


### PR DESCRIPTION
Added the "importance" field in the markdown files corresponding to the individual sheets in the ghga_submission_full.xlsx

Understandably, the importance field could take one of three values:
1. required
2. recommended
3. optional

As of now, there is only one field "required" which is a boolean (True|False), which is also not so intuitive for experimentalists/people working on the bench.