### PR TITLE
configuration change to be able to use absolute links

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -44,6 +44,11 @@ strict: false
 extra_css:
   - css/extra.css
 
+# Validation https://www.mkdocs.org/user-guide/configuration/#validation
+validation:
+  links:
+    absolute_links: relative_to_docs  # Or 'relative_to_docs' - new in MkDocs 1.6
+
 # Plugins
 plugins:
   - search

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs
+mkdocs>=1.6
 mkdocs-material
 mkdocs-ezglossary-plugin
 pygments

--- a/user_docs/snippets/submission_limitations.md
+++ b/user_docs/snippets/submission_limitations.md
@@ -1,5 +1,5 @@
 !!! info "Limitations on External Submissions - November 2024"
 
-    GHGA has only recently launched the functionality of the GHGA Data Portal. Our ongoing efforts concentrate on improving the data upload processes and the overall user experience for external submissions. In general, data upload by external users is not yet possible as it includes manual steps. See also this section in our [FAQ](./faq.md#how-to-upload-your-data-to-the-ghga-data-portal) and the [respective user story](./user_stories/submission/submitting_data.md).
+    GHGA has only recently launched the functionality of the GHGA Data Portal. Our ongoing efforts concentrate on improving the data upload processes and the overall user experience for external submissions. In general, data upload by external users is not yet possible as it includes manual steps. See also this section in our [FAQ](/faq.md#how-to-upload-your-data-to-the-ghga-data-portal) and the [respective user story](/user_stories/submission/submitting_data.md).
 
     


### PR DESCRIPTION
The links introduced via snippets did not work. With this new configuration this should be solved, see the documentation here: https://github.com/squidfunk/mkdocs-material/discussions/5897#discussioncomment-10940872 

Note: this need an update to mkdocs V1.6, run

`pip install --upgrade --force-reinstall mkdocs`

if you get error messages during the build.