### PR TITLE
Fix typo in DPC preparation documentation

### DIFF
--- a/user_docs/user_stories/submission/dpc_preparation.md
+++ b/user_docs/user_stories/submission/dpc_preparation.md
@@ -14,7 +14,7 @@ The DPC creates a controller-to-processor relationship between the institution a
 
 ### Data Submission to GHGA from DKFZ Scientists
 
-![DKFZ Logo](../../assets/img/DKFZ_solo.png){ align=right}For submissions in which the DKFZ is the <general:Research Data Controller (RDC)>, instead of agreeing to a <general:Data Processing Contract (DPC)|DPC> the responsible scientists need to sign the DKFZ Internal Terms of Use for data deposition in GHGA. The Internal Terms of Use are availbe [here in the DKFZ Intranet](https://intranet.dkfz.de/services/wissenschaftliche-dienste/deutsches-humangenom-phaenomarchiv-ghga). 
+![DKFZ Logo](../../assets/img/DKFZ_solo.png){ align=right}For submissions in which the DKFZ is the <general:Research Data Controller (RDC)>, instead of agreeing to a <general:Data Processing Contract (DPC)|DPC> the responsible scientists need to sign the DKFZ Internal Terms of Use for data deposition in GHGA. The Internal Terms of Use are available [here in the DKFZ Intranet](https://intranet.dkfz.de/services/wissenschaftliche-dienste/deutsches-humangenom-phaenomarchiv-ghga). 
 
 ## Checklist for legal pre-requisites for data submission to GHGA
 


### PR DESCRIPTION
Corrected a typo in the DKFZ Internal Terms of Use section.

We can fix the link to the ODCF wiki later.